### PR TITLE
fixed the bug on issue #52

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -191,10 +191,11 @@ var mapView = {
 
     for (var k in events){
       if (events.hasOwnProperty(k)) {
-        let renk = events[k];
+        //let renk = events[k];
         socket_io.on(k+':'+self.settings.users[0], function (data) {
           //console.log(data);
           if(data['data']['msg'] != null && data['data']['msg'] !== prevMsg){
+            var renk = events[data['event']];
             if (logThis.test(data['event'])) {
               if (data['event'] == 'vip_pokemon') {
                 timeOut = 8000;


### PR DESCRIPTION
This will just be a temporary fix... Once safari supports `let`, we'll just uncomment the line where `let` is used and remove the one I've added.
